### PR TITLE
Revive pipeline fixes and transcription stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,6 @@ ansible/vault/
 ansible/*.vault
 ansible/*.vault.yml
 ansible/*.vault.yaml
+
+# Downloaded reference audio samples (see scripts/fetch_sample_audio.py)
+data/samples/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in GitHub Issues (`pkuppens/healthcare-aigent`) via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical labels: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For detailed technical information, see [Technical Implementation](docs/technica
 - **[CrewAI Configuration](docs/crewai.md)**: Multi-agent system configuration
 - **[Testing Guidelines](docs/testing.md)**: Testing framework and best practices
 - **[Transcription Stage](docs/transcription.md)**: Turning a recorded consultation into text ahead of the pipeline
+- **[Compliance Considerations](docs/compliance.md)**: AVG / NEN 7510-7512-7513 / human-review context for a GGZ-style deployment
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ For detailed technical information, see [Technical Implementation](docs/technica
 - **[Development Environment](docs/development_environment.md)**: Setup and development guidelines
 - **[CrewAI Configuration](docs/crewai.md)**: Multi-agent system configuration
 - **[Testing Guidelines](docs/testing.md)**: Testing framework and best practices
+- **[Transcription Stage](docs/transcription.md)**: Turning a recorded consultation into text ahead of the pipeline
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ pytest
 pytest --cov=src
 ```
 
+Tests are split into unit tests (always run, no external services) and
+integration tests marked `@pytest.mark.integration` / `@pytest.mark.llm`,
+which auto-skip when no Ollama server or OpenAI API key is available (see
+`tests/conftest.py`). To exercise the live-LLM tests, either run
+`ollama serve && ollama pull llama3`, or set `OPENAI_API_KEY`.
+
+**Windows note**: a dependency (`litellm`, pulled in via `crewai`) reads a
+data file without specifying UTF-8 encoding, which fails under Windows'
+default `cp1252` codec. Run tests with `PYTHONUTF8=1` set, e.g.
+`PYTHONUTF8=1 uv run pytest` (Git Bash) or `$env:PYTHONUTF8=1; uv run pytest`
+(PowerShell).
+
 ## License
 
 This project is licensed under the MIT License with Commercial Use Restriction. See the [LICENSE](LICENSE) file for details.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (this repo):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| --------------------------- | --------------------- | ----------------------------------------- |
+| `needs-triage`              | `needs-triage`        | Maintainer needs to evaluate this issue   |
+| `needs-info`                | `needs-info`          | Waiting on reporter for more information  |
+| `ready-for-agent`           | `ready-for-agent`     | Fully specified, ready for an AFK agent   |
+| `ready-for-human`           | `ready-for-human`     | Requires human implementation             |
+| `wontfix`                   | `wontfix`             | Will not be actioned                      |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,60 @@
+# Compliance Considerations (GGZ / Healthcare Context)
+
+This is a proof-of-concept system using mocked data and no real patient
+information. It is **not** compliant or certified for production use in
+healthcare — the notes below describe how the architecture anticipates the
+relevant frameworks, not a claim that those frameworks are satisfied today.
+
+## Frameworks relevant to this domain
+
+- **AVG (GDPR)**: patient conversations and derived data (transcripts,
+  extracted clinical info, summaries) are special-category health data under
+  Art. 9 GDPR. Any real deployment needs an explicit legal basis, data
+  minimization, and a documented retention policy.
+- **NEN 7510 / 7512 / 7513**: the Dutch information security, secure data
+  exchange, and logging/accountability standards for healthcare information
+  systems. NEN 7510 in particular expects a documented ISMS (risk
+  assessment, access control, incident handling) around a system like this
+  one — not just secure code.
+- **Medisch beroepsgeheim**: professional confidentiality applies to the
+  treating clinician, not to the tooling. A system that surfaces AI-generated
+  content to a clinician must make clear that the clinician remains
+  responsible for what goes in the record — reflected here in
+  `quality_check.requires_human_review` (see below).
+- **Verwerkersovereenkomst / subverwerkersovereenkomst**: any third-party
+  processor in the pipeline (an LLM API, a transcription API, cloud hosting)
+  needs a data processing agreement, and its subprocessors need one in turn.
+  `src/llm/llm_factory.py` and `src/transcription/openai_whisper.py` currently
+  call OpenAI directly with no such agreement in place — fine for a demo with
+  synthetic text, not acceptable for real patient data.
+
+## Where the architecture already anticipates this
+
+- **Mandatory human review is structural, not optional.** `QualityControlTask`
+  (`src/tasks/quality_control_task.py`) always returns a
+  `requires_human_review` flag; nothing in the pipeline marks a report as
+  final without it. This is the direct analogue of "verplichte menselijke
+  beoordeling" in the job description.
+- **Provider abstraction isolates the compliance-sensitive boundary.**
+  `BaseLLM` (`src/llm/base.py`) and `TranscriptionService`
+  (`src/transcription/base.py`) mean the actual processor — OpenAI today,
+  potentially AWS Bedrock / AWS Transcribe in `eu-central-1` for a real
+  deployment — is a swappable implementation behind one interface, not
+  something wired through the whole codebase. Moving to a processor covered
+  by a signed agreement is a new class, not a rewrite.
+- **Audit logging is a first-class step, not an afterthought.**
+  `QualityControlTask` logs every quality-control event via
+  `logger.log_audit_event` (see `src/tools/logging_tools.py`,
+  `src/tools/database_interface.py`), which is the kind of accountability
+  trail NEN 7513 expects — currently backed by a mock/in-memory
+  implementation, but behind the same `HealthcareDatabase` interface a real
+  audit store would use.
+
+## What's genuinely missing
+
+- No multi-tenant isolation model (single-tenant PoC).
+- No AWS deployment (local/dev only).
+- No signed data processing agreements with the LLM/transcription providers
+  in use here — do not run real patient data through this code as-is.
+- No formal risk assessment or ISMS documentation (NEN 7510 is an
+  organizational standard as much as a technical one).

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -58,3 +58,7 @@ relevant frameworks, not a claim that those frameworks are satisfied today.
   in use here — do not run real patient data through this code as-is.
 - No formal risk assessment or ISMS documentation (NEN 7510 is an
   organizational standard as much as a technical one).
+- No speaker diarization in the transcription stage — the transcript can't
+  yet distinguish behandelaar from patiënt, which the human reviewer would
+  need in order to actually verify a concept report against what was said.
+  See [transcription.md](transcription.md#next-step-speaker-diarization).

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -60,3 +60,48 @@ see the HoMed project (Homo Medicinalis):
 <https://aclanthology.org/2022.lrec-1.110/>. Publicly available medical
 consultation audio in Dutch is scarce; the datasets that exist
 (e.g. FutureBeeAI's healthcare call-center Dutch corpus) are commercial.
+
+## Next step: speaker diarization
+
+**Not implemented.** `OpenAIWhisperTranscription` calls `whisper-1`, which
+returns one undifferentiated block of text — no "who said this" information.
+That's a real gap here, not a cosmetic one: a GGZ consult report needs to
+distinguish behandelaar from patiënt, and `tests/conftest.py`'s
+`mock_transcript` fixture already models the target shape
+(`Spreker A: ... / Spreker B: ...`) that nothing upstream currently produces.
+
+### Option 1 — AWS Transcribe (most relevant for this job's architecture)
+
+Since the target deployment is AWS eu-central-1, AWS Transcribe is the
+natural production choice over a self-managed OSS pipeline: it does
+transcription *and* speaker diarization in one call
+(`ShowSpeakerLabels=True` / `Settings.ShowSpeakerLabels` in the
+`start_transcription_job` API), runs inside the AWS account and region
+already in scope, and its data handling is covered by AWS's standard data
+processing terms rather than a separate third-party agreement. This would
+likely be the right implementation to add as a second `TranscriptionService`
+alongside (or instead of) the OpenAI one, returning speaker-labeled segments.
+
+### Option 2 — Open-source, for a self-hosted / non-AWS path
+
+- **[WhisperX](https://github.com/m-bain/whisperX)** — wraps faster-whisper
+  with forced word-level alignment and integrates `pyannote.audio` for
+  diarization in one pipeline; the most common off-the-shelf combination for
+  "Whisper transcript + speaker labels."
+- **[pyannote.audio](https://github.com/pyannote/pyannote-audio)** — the
+  diarization engine WhisperX (and most others) build on. Can also be run
+  standalone and its speaker segments merged with any ASR output's
+  timestamps after the fact. Pretrained pipeline:
+  `pyannote/speaker-diarization-3.1` on Hugging Face (gated, free to accept).
+- **[NVIDIA NeMo](https://github.com/NVIDIA/NeMo)** speaker diarization
+  toolkit — more heavyweight (GPU-oriented), relevant if the deployment
+  already standardizes on NeMo/Riva for ASR.
+
+### Interface impact
+
+`TranscriptionService.transcribe` currently returns `str`. Diarization
+requires returning structured turns instead — e.g. a small
+`TranscriptSegment(speaker: str, text: str, start: float, end: float)` list
+— which is a breaking change to the interface, not an additive one. Worth
+making before wiring a second provider, so both implementations share the
+same richer contract from the start rather than retrofitting it.

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -1,26 +1,42 @@
 # Transcription Stage
 
-`src/transcription/` turns a recorded consultation into text, as the first
-stage ahead of the existing agent/task pipeline (preprocess → assess
-language → extract clinical info → summarize → quality control).
+`src/transcription/` is the entry point that lets this system take a
+recorded consultation, instead of only pre-transcribed text, as input: it
+turns the audio into a transcript, then hands that transcript to the
+existing agent/task pipeline unchanged (preprocess → assess language →
+extract clinical info → summarize → quality control). It exists so a real
+GGZ workflow — "record the consult, get a concept report" — can be
+demonstrated end to end, not just the text-only half of it.
+
+**Not implemented yet: speaker diarization** (who said what). See
+["Next step: speaker diarization"](#next-step-speaker-diarization) below —
+the transcript today is one undifferentiated block of text.
 
 ## Interface
 
-`TranscriptionService` (`src/transcription/base.py`) is a one-method
-interface — `async def transcribe(audio_path, language=None) -> str` —
-mirroring the `BaseLLM` provider abstraction in `src/llm/`. The only
-implementation today is `OpenAIWhisperTranscription`
-(`src/transcription/openai_whisper.py`), which calls OpenAI's hosted
-`whisper-1` model.
+`TranscriptionService` (`src/transcription/base.py`) is a small interface —
+`async def transcribe(audio, *, filename, language=None) -> str`, working on
+in-memory audio bytes rather than a filesystem path, plus a
+`transcribe_file(audio_path, language=None)` convenience wrapper for
+callers that only have a file on disk — mirroring the `BaseLLM` provider
+abstraction in `src/llm/`. The only implementation today is
+`OpenAIWhisperTranscription` (`src/transcription/openai_whisper.py`), which
+calls OpenAI's hosted `whisper-1` model.
 
 This is a showcase stub, not a production transcription pipeline. See
-[compliance.md](compliance.md) for why sending real patient audio through it
-as-is would be a problem.
+[compliance.md, "What's genuinely missing"](compliance.md#whats-genuinely-missing)
+for why sending real patient audio through it as-is would be a problem: no
+signed data processing agreement is in place with OpenAI.
 
-**Swapping providers**: a real deployment would likely replace this with a
-provider that fits the eu-central-1 / multi-tenant AWS setup — e.g. AWS
-Transcribe, or a self-hosted Whisper deployment. That's a new
-`TranscriptionService` implementation; nothing else in the pipeline changes.
+**Swapping providers**: `src/transcription/factory.py`'s
+`TranscriptionFactory` selects the implementation via the
+`TRANSCRIPTION_PROVIDER` env var (defaults to `openai`). A real deployment
+would likely add a provider that fits the eu-central-1 / multi-tenant AWS
+setup — e.g. AWS Transcribe, or a self-hosted Whisper deployment — as a new
+`TranscriptionService` implementation registered in that factory; nothing
+else in the pipeline changes. See
+[transcription_research.md](transcription_research.md) for the tradeoffs
+between candidate providers.
 
 ## Entry points
 
@@ -43,7 +59,10 @@ uv run python scripts/fetch_sample_audio.py
 ```
 
 This writes a few `.wav` clips to `data/samples/` (git-ignored — not
-committed). Then, with `OPENAI_API_KEY` set:
+committed). Then, with the configured provider's credentials set (the
+default `openai` provider needs `OPENAI_API_KEY`; see "Swapping providers"
+above and [transcription_research.md](transcription_research.md) for the
+other providers this is meant to support):
 
 ```python
 import asyncio
@@ -70,7 +89,9 @@ distinguish behandelaar from patiënt, and `tests/conftest.py`'s
 `mock_transcript` fixture already models the target shape
 (`Spreker A: ... / Spreker B: ...`) that nothing upstream currently produces.
 
-### Option 1 — AWS Transcribe (most relevant for this job's architecture)
+### Option 1 — Cloud solutions
+
+#### 1.1 AWS Transcribe (most relevant for this job's architecture)
 
 Since the target deployment is AWS eu-central-1, AWS Transcribe is the
 natural production choice over a self-managed OSS pipeline: it does
@@ -81,6 +102,17 @@ already in scope, and its data handling is covered by AWS's standard data
 processing terms rather than a separate third-party agreement. This would
 likely be the right implementation to add as a second `TranscriptionService`
 alongside (or instead of) the OpenAI one, returning speaker-labeled segments.
+
+#### 1.2 Azure Speech-to-Text — not yet researched
+
+#### 1.3 Google Cloud Speech-to-Text — not yet researched
+
+Both 1.2 and 1.3 do speaker diarization and have EU-hosting options in
+principle; neither has been evaluated here for Dutch-language quality,
+cost, or their data processing agreement terms. See
+[transcription_research.md](transcription_research.md), which is where that
+evaluation (including a full comparison matrix against AWS Transcribe and
+the open-source options below) belongs once it's done.
 
 ### Option 2 — Open-source, for a self-hosted / non-AWS path
 

--- a/docs/transcription.md
+++ b/docs/transcription.md
@@ -1,0 +1,62 @@
+# Transcription Stage
+
+`src/transcription/` turns a recorded consultation into text, as the first
+stage ahead of the existing agent/task pipeline (preprocess → assess
+language → extract clinical info → summarize → quality control).
+
+## Interface
+
+`TranscriptionService` (`src/transcription/base.py`) is a one-method
+interface — `async def transcribe(audio_path, language=None) -> str` —
+mirroring the `BaseLLM` provider abstraction in `src/llm/`. The only
+implementation today is `OpenAIWhisperTranscription`
+(`src/transcription/openai_whisper.py`), which calls OpenAI's hosted
+`whisper-1` model.
+
+This is a showcase stub, not a production transcription pipeline. See
+[compliance.md](compliance.md) for why sending real patient audio through it
+as-is would be a problem.
+
+**Swapping providers**: a real deployment would likely replace this with a
+provider that fits the eu-central-1 / multi-tenant AWS setup — e.g. AWS
+Transcribe, or a self-hosted Whisper deployment. That's a new
+`TranscriptionService` implementation; nothing else in the pipeline changes.
+
+## Entry points
+
+- `process_audio_conversation_async(audio_path, ...)` in `src/main.py` —
+  transcribes, then runs the same task pipeline as the text-only entry
+  point, returning the transcript alongside the structured results.
+- `POST /transcribe_and_process/` in `src/api/api_server.py` — the HTTP
+  equivalent, accepting a multipart file upload.
+
+## Manually testing with reference audio
+
+There's no medical-domain Dutch audio that's both public and freely
+licensed (see below), so `scripts/fetch_sample_audio.py` pulls general-domain
+Dutch speech from Mozilla Common Voice (CC0) for manual testing of the
+transcription stage:
+
+```bash
+uv sync --extra audio
+uv run python scripts/fetch_sample_audio.py
+```
+
+This writes a few `.wav` clips to `data/samples/` (git-ignored — not
+committed). Then, with `OPENAI_API_KEY` set:
+
+```python
+import asyncio
+from src.main import process_audio_conversation_async
+
+result = asyncio.run(process_audio_conversation_async("data/samples/common_voice_nl_00.wav"))
+print(result["transcript"])
+```
+
+**On domain fit**: Common Voice is general read speech, not medical
+dialogue — it exercises the transcription *wiring*, not medical-terminology
+accuracy. For the closest published work on open Dutch medical-domain ASR,
+see the HoMed project (Homo Medicinalis):
+<https://aclanthology.org/2022.lrec-1.110/>. Publicly available medical
+consultation audio in Dutch is scarce; the datasets that exist
+(e.g. FutureBeeAI's healthcare call-center Dutch corpus) are commercial.

--- a/docs/transcription_research.md
+++ b/docs/transcription_research.md
@@ -1,0 +1,47 @@
+# Transcription Provider Research
+
+Referenced from [transcription.md](transcription.md). `TranscriptionService`
+(`src/transcription/base.py`) has one implementation today — OpenAI's hosted
+Whisper API. This document is the place to research and record the tradeoffs
+between that and the other candidate providers before picking what a real
+deployment should use.
+
+**Status: not yet performed.** This is the structure the research should
+fill in, not a completed evaluation — the rows below are placeholders.
+
+## Candidate providers
+
+- **OpenAI Whisper API** (`whisper-1`) — implemented today
+  (`src/transcription/openai_whisper.py`).
+- **Local Whisper** (e.g. `faster-whisper`, `openai-whisper`) — self-hosted,
+  no audio leaves the deployment, but needs GPU/CPU capacity planning.
+- **AWS Transcribe** — see
+  [transcription.md, Option 1.1](transcription.md#option-1--cloud-solutions)
+  for why this is the leading cloud candidate for this project's
+  eu-central-1 AWS architecture (also does speaker diarization natively).
+- **Azure Speech-to-Text** — relevant if the deployment standardizes on
+  Azure instead of AWS; EU data-residency options exist and need checking.
+- **Google Cloud Speech-to-Text / Gemini audio input** — same category as
+  Azure; EU data-residency and healthcare-data terms need checking.
+
+## Evaluation dimensions
+
+For each provider above, this research should record:
+
+| Dimension | Notes |
+|---|---|
+| Transcription quality (esp. Dutch, medical terminology) | No medical-domain Dutch benchmark audio is freely available — see transcription.md's "Manually testing" section for what's used instead. |
+| Speaker diarization support | Native vs. requires a separate pipeline stage (see transcription.md's diarization section). |
+| Latency / throughput | Batch (offline) vs. streaming; matters for a live-consult use case vs. after-the-fact processing. |
+| Cost | Per-minute pricing, at the volume this project would realistically run at. |
+| Data residency / hosting region | EU hosting availability (eu-central-1 or equivalent). |
+| Compliance / data processing agreement | Whether a signed verwerkersovereenkomst is available for this provider — see [compliance.md](compliance.md). |
+| Local/self-hosted option | Whether a non-cloud path exists, and its infra cost. |
+
+## Recommendation
+
+Not yet made — depends on the results above. `docs/transcription.md`'s
+"Swapping providers" section describes the mechanism (a new
+`TranscriptionService` implementation, registered in
+`src/transcription/factory.py`); this document is where the *choice* of
+which one to build next should be justified once the research is done.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
 ]
+audio = [
+    # Only needed to run scripts/fetch_sample_audio.py — pulls reference
+    # Dutch/multilingual clips for manually exercising the transcription stage.
+    "datasets>=2.14.0",
+    "soundfile>=0.12.0",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]

--- a/scripts/fetch_sample_audio.py
+++ b/scripts/fetch_sample_audio.py
@@ -1,0 +1,80 @@
+"""Fetch a handful of reference audio clips for manually exercising the
+transcription stage (`src/transcription`).
+
+Source: Mozilla Common Voice, Dutch config ("nl"), validated split.
+  https://commonvoice.mozilla.org/en/datasets
+  https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0
+
+Common Voice is released under CC0 (public domain) — free to use, no
+attribution required, no ToS/scraping concerns. It isn't healthcare-specific
+(general read speech), which is a known gap: see the HoMed project
+(https://aclanthology.org/2022.lrec-1.110/) for the closest published work on
+open Dutch medical-domain ASR, and docs/agents/domain.md / docs/transcription.md
+for how this repo's transcription stage should evolve if real clinical audio
+becomes available.
+
+Usage:
+    uv sync --extra audio
+    uv run python scripts/fetch_sample_audio.py
+
+Downloaded clips are written to data/samples/ (git-ignored) and are NOT
+committed to the repository.
+
+Note: Hugging Face gates some Common Voice releases behind a click-through
+license acceptance. If this script errors with a 401/403, accept the dataset
+terms at the URL above while logged in, then run `huggingface-cli login`
+(from the `huggingface_hub` package) and retry.
+"""
+
+import sys
+from pathlib import Path
+
+
+SAMPLE_COUNT = 3
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "data" / "samples"
+
+
+def main() -> None:
+    try:
+        import soundfile as sf
+        from datasets import load_dataset
+    except ImportError:
+        print(
+            "Missing optional dependencies. Install them with:\n    uv sync --extra audio",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("Streaming Dutch validated clips from mozilla-foundation/common_voice_17_0 ...")
+    try:
+        dataset = load_dataset(
+            "mozilla-foundation/common_voice_17_0",
+            "nl",
+            split="validated",
+            streaming=True,
+            trust_remote_code=True,
+        )
+    except Exception as e:
+        print(
+            f"Failed to open the dataset: {e}\n\n"
+            "If this is an authentication/gating error, accept the dataset terms at\n"
+            "https://huggingface.co/datasets/mozilla-foundation/common_voice_17_0\n"
+            "then run `huggingface-cli login` and retry.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    for i, example in enumerate(dataset.take(SAMPLE_COUNT)):
+        audio = example["audio"]
+        out_path = OUTPUT_DIR / f"common_voice_nl_{i:02d}.wav"
+        sf.write(out_path, audio["array"], audio["sampling_rate"])
+        sentence = example.get("sentence", "<no transcript in dataset>")
+        print(f"Wrote {out_path} — reference transcript: {sentence!r}")
+
+    print(f"\nDone. {SAMPLE_COUNT} clip(s) written to {OUTPUT_DIR}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/api/api_server.py
+++ b/src/api/api_server.py
@@ -84,9 +84,13 @@ async def transcribe_and_process_endpoint(audio: UploadFile, language: str = "nl
     `quality_check.requires_human_review` before it can be used.
 
     Note: this is a showcase implementation. Audio is written to a local temp
-    file and sent to OpenAI's Whisper API; it is not routed through any
-    signed subverwerkersovereenkomst and must not be used with real patient
-    data. See docs/agents/domain.md for the compliance context.
+    file and sent to whichever transcription provider is configured (OpenAI's
+    Whisper API by default — see `TRANSCRIPTION_PROVIDER` in
+    `src/transcription/factory.py` for how to change it); none of the
+    supported providers today are routed through a signed
+    subverwerkersovereenkomst, so this must not be used with real patient
+    data regardless of provider. See docs/agents/domain.md for the
+    compliance context.
 
     Args:
         audio: The uploaded audio file (recorded consultation).

--- a/src/api/api_server.py
+++ b/src/api/api_server.py
@@ -7,7 +7,7 @@ processing medical conversations. It serves as the API gateway for the system.
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from src.main import process_medical_conversation
+from src.main import process_medical_conversation_async
 
 
 app = FastAPI(
@@ -69,4 +69,4 @@ async def process_conversation_endpoint(request: ConversationRequest) -> dict:
         }
         ```
     """
-    return process_medical_conversation(request.text)
+    return await process_medical_conversation_async(request.text)

--- a/src/api/api_server.py
+++ b/src/api/api_server.py
@@ -4,10 +4,13 @@ This module creates a FastAPI application that exposes an endpoint for
 processing medical conversations. It serves as the API gateway for the system.
 """
 
-from fastapi import FastAPI
+import tempfile
+from pathlib import Path
+
+from fastapi import FastAPI, UploadFile
 from pydantic import BaseModel
 
-from src.main import process_medical_conversation_async
+from src.main import process_audio_conversation_async, process_medical_conversation_async
 
 
 app = FastAPI(
@@ -70,3 +73,35 @@ async def process_conversation_endpoint(request: ConversationRequest) -> dict:
         ```
     """
     return await process_medical_conversation_async(request.text)
+
+
+@app.post("/transcribe_and_process/", summary="Transcribe a recorded consultation and process it")
+async def transcribe_and_process_endpoint(audio: UploadFile, language: str = "nl") -> dict:
+    """Transcribes an uploaded consultation recording and runs it through the pipeline.
+
+    This is the entry point that matches the real GGZ workflow: a recorded
+    consult in, a structured concept report out — still gated by
+    `quality_check.requires_human_review` before it can be used.
+
+    Note: this is a showcase implementation. Audio is written to a local temp
+    file and sent to OpenAI's Whisper API; it is not routed through any
+    signed subverwerkersovereenkomst and must not be used with real patient
+    data. See docs/agents/domain.md for the compliance context.
+
+    Args:
+        audio: The uploaded audio file (recorded consultation).
+        language: ISO 639-1 language hint for the transcriber (default "nl").
+
+    Returns:
+        A dictionary with the transcript plus the same structured results as
+        `/process_conversation/`.
+    """
+    suffix = Path(audio.filename or "").suffix or ".wav"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp.write(await audio.read())
+        tmp_path = tmp.name
+
+    try:
+        return await process_audio_conversation_async(tmp_path, language=language)
+    finally:
+        Path(tmp_path).unlink(missing_ok=True)

--- a/src/llm/base.py
+++ b/src/llm/base.py
@@ -98,6 +98,23 @@ class BaseLLM(ABC):
         """
         pass
 
+    async def ainvoke(self, prompt: str, **kwargs: Any) -> str:
+        """Invoke the LLM asynchronously with the given prompt.
+
+        The underlying provider clients (ChatOpenAI/ChatOllama) are called
+        synchronously via `_call`; this just gives callers (e.g. the task
+        pipeline in `src/tasks`, which is written against an async LLM
+        interface) a consistent `ainvoke` regardless of provider.
+
+        Args:
+            prompt: The prompt to send to the LLM
+            **kwargs: Additional arguments to pass to the LLM
+
+        Returns:
+            The generated text from the LLM
+        """
+        return self._call(prompt, **kwargs)
+
     def invoke(self, prompt: str, **kwargs: Any) -> str:
         """Invoke the LLM with the given prompt.
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.tasks import (
 )
 from src.tools.logging_tools import Logger
 from src.tools.mock_database import MockHealthcareDatabase
+from src.transcription.base import TranscriptionService
 
 
 class _QualityControlDataSource:
@@ -74,6 +75,39 @@ async def process_medical_conversation_async(conversation: str, patient_id: str 
         "summary": summary,
         "quality_check": quality_check,
     }
+
+
+async def process_audio_conversation_async(
+    audio_path: str,
+    transcription_service: TranscriptionService | None = None,
+    patient_id: str = "demo-patient",
+    language: str | None = "nl",
+) -> dict:
+    """Transcribes a recorded consultation, then runs it through the task pipeline.
+
+    This is the entry point closest to the real GGZ use case: a recorded
+    consult goes in, a structured concept report (still requiring human
+    review — see `quality_check.requires_human_review`) comes out.
+
+    Args:
+        audio_path: Path to the recorded consultation audio file.
+        transcription_service: The provider to transcribe with. Defaults to
+            `OpenAIWhisperTranscription` (requires OPENAI_API_KEY).
+        patient_id: The patient to verify the summary against.
+        language: Optional ISO 639-1 language hint passed to the transcriber.
+
+    Returns:
+        A dictionary with the transcript plus the same structured results as
+        `process_medical_conversation_async`.
+    """
+    if transcription_service is None:
+        from src.transcription.openai_whisper import OpenAIWhisperTranscription
+
+        transcription_service = OpenAIWhisperTranscription()
+
+    transcript = await transcription_service.transcribe(audio_path, language=language)
+    result = await process_medical_conversation_async(transcript, patient_id)
+    return {"transcript": transcript, **result}
 
 
 def process_medical_conversation(conversation: str, patient_id: str = "demo-patient") -> dict:

--- a/src/main.py
+++ b/src/main.py
@@ -1,14 +1,14 @@
 """Main module for the healthcare multi-agent system.
 
-This module serves as the primary entry point for running the healthcare AI agent crew.
-It defines the main workflow for processing a medical conversation, from initializing
-the language model and agents to executing the tasks and returning the final results.
+This module serves as the primary entry point for running the healthcare AI agent
+pipeline. It defines the main workflow for processing a medical conversation, from
+initializing the language model to executing each task in sequence and returning
+the final, structured results.
 """
 
-from crewai import Crew, Process
+import asyncio
 
-from src.agents import create_medical_crew
-from src.llm.llm_factory import LLMFactory, LLMType
+from src.llm.llm_factory import LLMFactory
 from src.tasks import (
     AssessPatientLanguageTask,
     ExtractClinicalInfoTask,
@@ -16,48 +16,81 @@ from src.tasks import (
     PreprocessMedicalTextTask,
     QualityControlTask,
 )
+from src.tools.logging_tools import Logger
+from src.tools.mock_database import MockHealthcareDatabase
 
 
-def process_medical_conversation(conversation: str) -> dict:
-    """Processes a medical conversation using the healthcare agent crew.
+class _QualityControlDataSource:
+    """Adapts the patient-keyed `HealthcareDatabase` interface to the no-arg
+    `db.read_patient_data()` call `QualityControlTask` makes, and fills in
+    defaults for demo patients with no history on file.
+    """
 
-    This function orchestrates the entire workflow. It initializes the language model
-    using the LLMFactory, creates the specialized agents, defines the sequence of tasks,
-    and runs the crew to get the processed results.
+    def __init__(self, db: MockHealthcareDatabase, patient_id: str):
+        self._db = db
+        self._patient_id = patient_id
+
+    async def read_patient_data(self) -> dict:
+        """Return the patient history/allergies used to verify the summary."""
+        data = await self._db.read_patient_data(self._patient_id)
+        return {
+            "history": data.get("history", "No prior history on file."),
+            "allergies": data.get("allergies", []),
+        }
+
+
+async def process_medical_conversation_async(conversation: str, patient_id: str = "demo-patient") -> dict:
+    """Processes a medical conversation using the healthcare agent task pipeline.
+
+    Runs the conversation through each task in sequence: preprocessing, language
+    assessment, clinical extraction, summarization, and quality control (which
+    flags whether a human reviewer must sign off before the output is used).
+
+    Use this directly from async callers (e.g. the FastAPI endpoint); use
+    `process_medical_conversation` from sync code such as the CLI entry point.
 
     Args:
         conversation: A string containing the medical conversation to be processed.
+        patient_id: The patient to verify the summary against. Defaults to a demo
+            patient with no history on file in the mock database.
 
     Returns:
         A dictionary containing the structured results from each task in the workflow.
     """
-    # Initialize the appropriate LLM using the factory
-    # We choose CLOUD_FAST as a default for general-purpose conversation processing.
-    llm = LLMFactory.create_llm(LLMType.CLOUD_FAST)
+    llm = LLMFactory.get_llm_for_task("summarization")
+    db = _QualityControlDataSource(MockHealthcareDatabase(), patient_id)
+    logger = Logger()
 
-    # Create agents
-    agents = create_medical_crew(llm)
-
-    # Create tasks
-    tasks = [
-        PreprocessMedicalTextTask(),
-        AssessPatientLanguageTask(),
-        ExtractClinicalInfoTask(),
-        GenerateSummaryTask(),
-        QualityControlTask(),
-    ]
-
-    # Create and run the crew
-    crew = Crew(agents=agents, tasks=tasks, process=Process.sequential, verbose=True)
-    result = crew.kickoff()
+    preprocessed_text = await PreprocessMedicalTextTask().execute(conversation, llm)
+    language_assessment = await AssessPatientLanguageTask().execute(preprocessed_text, llm)
+    clinical_info = await ExtractClinicalInfoTask().execute(preprocessed_text, llm)
+    summary = await GenerateSummaryTask().execute(preprocessed_text, llm)
+    quality_check = await QualityControlTask().execute(summary, llm, db, logger)
 
     return {
-        "preprocessed_text": result[0],
-        "language_assessment": result[1],
-        "clinical_info": result[2],
-        "summary": result[3],
-        "quality_check": result[4],
+        "preprocessed_text": preprocessed_text,
+        "language_assessment": language_assessment,
+        "clinical_info": clinical_info,
+        "summary": summary,
+        "quality_check": quality_check,
     }
+
+
+def process_medical_conversation(conversation: str, patient_id: str = "demo-patient") -> dict:
+    """Synchronous wrapper around `process_medical_conversation_async` for CLI/script use.
+
+    Do not call this from within an already-running event loop (e.g. inside a
+    FastAPI async endpoint) — `asyncio.run` will raise. Use
+    `process_medical_conversation_async` there instead.
+
+    Args:
+        conversation: A string containing the medical conversation to be processed.
+        patient_id: The patient to verify the summary against.
+
+    Returns:
+        A dictionary containing the structured results from each task in the workflow.
+    """
+    return asyncio.run(process_medical_conversation_async(conversation, patient_id))
 
 
 def main():

--- a/src/main.py
+++ b/src/main.py
@@ -92,7 +92,8 @@ async def process_audio_conversation_async(
     Args:
         audio_path: Path to the recorded consultation audio file.
         transcription_service: The provider to transcribe with. Defaults to
-            `OpenAIWhisperTranscription` (requires OPENAI_API_KEY).
+            `TranscriptionFactory.create()`, i.e. whatever `TRANSCRIPTION_PROVIDER`
+            selects (OpenAI Whisper, requiring OPENAI_API_KEY, by default).
         patient_id: The patient to verify the summary against.
         language: Optional ISO 639-1 language hint passed to the transcriber.
 
@@ -101,11 +102,11 @@ async def process_audio_conversation_async(
         `process_medical_conversation_async`.
     """
     if transcription_service is None:
-        from src.transcription.openai_whisper import OpenAIWhisperTranscription
+        from src.transcription.factory import TranscriptionFactory
 
-        transcription_service = OpenAIWhisperTranscription()
+        transcription_service = TranscriptionFactory.create()
 
-    transcript = await transcription_service.transcribe(audio_path, language=language)
+    transcript = await transcription_service.transcribe_file(audio_path, language=language)
     result = await process_medical_conversation_async(transcript, patient_id)
     return {"transcript": transcript, **result}
 

--- a/src/transcription/__init__.py
+++ b/src/transcription/__init__.py
@@ -1,0 +1,13 @@
+"""Transcription providers for turning recorded consultations into text.
+
+This package mirrors the `src/llm` provider-abstraction pattern: a
+`TranscriptionService` interface with one or more concrete implementations,
+so the rest of the pipeline (`src/tasks`) never needs to know which provider
+produced the transcript.
+"""
+
+from src.transcription.base import TranscriptionService
+from src.transcription.openai_whisper import OpenAIWhisperTranscription
+
+
+__all__ = ["TranscriptionService", "OpenAIWhisperTranscription"]

--- a/src/transcription/__init__.py
+++ b/src/transcription/__init__.py
@@ -7,7 +7,8 @@ produced the transcript.
 """
 
 from src.transcription.base import TranscriptionService
+from src.transcription.factory import TranscriptionFactory
 from src.transcription.openai_whisper import OpenAIWhisperTranscription
 
 
-__all__ = ["TranscriptionService", "OpenAIWhisperTranscription"]
+__all__ = ["TranscriptionFactory", "TranscriptionService", "OpenAIWhisperTranscription"]

--- a/src/transcription/base.py
+++ b/src/transcription/base.py
@@ -21,11 +21,18 @@ class TranscriptionService(ABC):
     """
 
     @abstractmethod
-    async def transcribe(self, audio_path: str | Path, language: str | None = None) -> str:
-        """Transcribe an audio file to text.
+    async def transcribe(self, audio: bytes, *, filename: str = "audio.wav", language: str | None = None) -> str:
+        """Transcribe raw audio bytes to text.
+
+        Implementations work on in-memory audio, not a filesystem path: the
+        source may just as well be an API upload or a microphone capture as
+        a file on disk, and a file is only one of several ways to get bytes
+        in front of a transcriber.
 
         Args:
-            audio_path: Path to the audio file (e.g. a recorded consultation).
+            audio: The raw audio bytes.
+            filename: Original filename, used by providers (e.g. OpenAI's
+                Whisper API) that infer the audio format from its extension.
             language: Optional ISO 639-1 language hint (e.g. "nl"). Providers
                 that support auto-detection may ignore this.
 
@@ -35,3 +42,26 @@ class TranscriptionService(ABC):
         Raises:
             RuntimeError: If transcription fails.
         """
+
+    async def transcribe_file(self, audio_path: str | Path, language: str | None = None) -> str:
+        """Convenience wrapper for callers that only have a file path (e.g.
+        CLI/script use, or `scripts/fetch_sample_audio.py` output).
+
+        Reads the file into memory and delegates to `transcribe`, so
+        individual providers never need to implement file-reading
+        themselves.
+
+        Args:
+            audio_path: Path to the audio file (e.g. a recorded consultation).
+            language: Optional ISO 639-1 language hint (e.g. "nl").
+
+        Returns:
+            The transcribed text.
+
+        Raises:
+            RuntimeError: If the file doesn't exist or transcription fails.
+        """
+        path = Path(audio_path)
+        if not path.is_file():
+            raise RuntimeError(f"Audio file not found: {path}")
+        return await self.transcribe(path.read_bytes(), filename=path.name, language=language)

--- a/src/transcription/base.py
+++ b/src/transcription/base.py
@@ -1,0 +1,31 @@
+"""Base interface for transcription providers."""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class TranscriptionService(ABC):
+    """Abstract interface for turning a recorded consultation into text.
+
+    A real deployment would swap this for a provider bound to its data
+    processing agreement (verwerkersovereenkomst) and hosting region — e.g.
+    AWS Transcribe in eu-central-1 for a multi-tenant EU setup. This
+    abstraction exists so that swap is a new implementation of this
+    interface, not a change to the pipeline that consumes it.
+    """
+
+    @abstractmethod
+    async def transcribe(self, audio_path: str | Path, language: str | None = None) -> str:
+        """Transcribe an audio file to text.
+
+        Args:
+            audio_path: Path to the audio file (e.g. a recorded consultation).
+            language: Optional ISO 639-1 language hint (e.g. "nl"). Providers
+                that support auto-detection may ignore this.
+
+        Returns:
+            The transcribed text.
+
+        Raises:
+            RuntimeError: If transcription fails.
+        """

--- a/src/transcription/base.py
+++ b/src/transcription/base.py
@@ -12,6 +12,12 @@ class TranscriptionService(ABC):
     AWS Transcribe in eu-central-1 for a multi-tenant EU setup. This
     abstraction exists so that swap is a new implementation of this
     interface, not a change to the pipeline that consumes it.
+
+    The `str` return type below is deliberately the simplest thing that
+    works today: it does not carry speaker turns or timestamps. See
+    docs/transcription.md ("Next step: speaker diarization") for why that's
+    a real gap for consult recordings and how the interface would need to
+    change (e.g. a `Transcript` with per-turn speaker labels) to close it.
     """
 
     @abstractmethod

--- a/src/transcription/factory.py
+++ b/src/transcription/factory.py
@@ -1,0 +1,43 @@
+"""Factory for creating the configured transcription provider.
+
+Mirrors `src/llm/llm_factory.py`'s provider-by-name pattern, kept minimal
+since only one provider is implemented today. See docs/transcription.md and
+docs/transcription_research.md for the providers this is meant to grow into
+(local Whisper, Azure, Google) and how they'd be compared.
+"""
+
+import os
+from typing import ClassVar
+
+from src.transcription.base import TranscriptionService
+from src.transcription.openai_whisper import OpenAIWhisperTranscription
+
+
+class TranscriptionFactory:
+    """Creates a `TranscriptionService` based on the `TRANSCRIPTION_PROVIDER` env var."""
+
+    _provider_map: ClassVar[dict[str, type[TranscriptionService]]] = {
+        "openai": OpenAIWhisperTranscription,
+    }
+
+    @classmethod
+    def create(cls, provider: str | None = None) -> TranscriptionService:
+        """Create the transcription provider to use.
+
+        Args:
+            provider: Provider name (e.g. "openai"). Defaults to the
+                `TRANSCRIPTION_PROVIDER` env var, then "openai".
+
+        Returns:
+            A configured `TranscriptionService`.
+
+        Raises:
+            ValueError: If the provider name isn't registered.
+        """
+        provider = (provider or os.getenv("TRANSCRIPTION_PROVIDER", "openai")).lower()
+
+        if provider not in cls._provider_map:
+            supported = ", ".join(sorted(cls._provider_map))
+            raise ValueError(f"Unsupported transcription provider: {provider!r} (supported: {supported})")
+
+        return cls._provider_map[provider]()

--- a/src/transcription/openai_whisper.py
+++ b/src/transcription/openai_whisper.py
@@ -1,0 +1,62 @@
+"""OpenAI Whisper API transcription provider."""
+
+import os
+from pathlib import Path
+
+from openai import AsyncOpenAI
+
+from src.transcription.base import TranscriptionService
+
+
+class OpenAIWhisperTranscription(TranscriptionService):
+    """Transcribes audio using OpenAI's hosted Whisper API (`whisper-1`).
+
+    This is the cloud option: no local model download, but audio leaves the
+    process boundary. For a real GGZ deployment this would need to run
+    somewhere covered by a signed subverwerkersovereenkomst (or be replaced
+    entirely by a self-hosted/AWS Transcribe pipeline) — this implementation
+    is a showcase stub, not a compliant path for real patient data.
+    """
+
+    def __init__(self, api_key: str | None = None, model: str = "whisper-1"):
+        """Initialize the provider.
+
+        Args:
+            api_key: OpenAI API key. Falls back to the OPENAI_API_KEY env var.
+            model: The Whisper model name to use.
+
+        Raises:
+            ValueError: If no API key is available.
+        """
+        self._api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self._api_key:
+            raise ValueError("OpenAI API key not provided and OPENAI_API_KEY environment variable not set")
+        self._model = model
+        self._client = AsyncOpenAI(api_key=self._api_key)
+
+    async def transcribe(self, audio_path: str | Path, language: str | None = None) -> str:
+        """Transcribe an audio file using the Whisper API.
+
+        Args:
+            audio_path: Path to the audio file.
+            language: Optional ISO 639-1 language hint (e.g. "nl").
+
+        Returns:
+            The transcribed text.
+
+        Raises:
+            RuntimeError: If the file doesn't exist or the API call fails.
+        """
+        path = Path(audio_path)
+        if not path.is_file():
+            raise RuntimeError(f"Audio file not found: {path}")
+
+        try:
+            with path.open("rb") as audio_file:
+                kwargs = {"model": self._model, "file": audio_file}
+                if language:
+                    kwargs["language"] = language
+                response = await self._client.audio.transcriptions.create(**kwargs)
+            return response.text
+        except Exception as e:
+            raise RuntimeError(f"Failed to transcribe {path.name}: {e}") from e

--- a/src/transcription/openai_whisper.py
+++ b/src/transcription/openai_whisper.py
@@ -1,7 +1,6 @@
 """OpenAI Whisper API transcription provider."""
 
 import os
-from pathlib import Path
 
 from openai import AsyncOpenAI
 
@@ -38,29 +37,29 @@ class OpenAIWhisperTranscription(TranscriptionService):
         self._model = model
         self._client = AsyncOpenAI(api_key=self._api_key)
 
-    async def transcribe(self, audio_path: str | Path, language: str | None = None) -> str:
-        """Transcribe an audio file using the Whisper API.
+    async def transcribe(self, audio: bytes, *, filename: str = "audio.wav", language: str | None = None) -> str:
+        """Transcribe raw audio bytes using the Whisper API.
+
+        The API takes the audio content directly — it never touches a
+        filesystem path — and infers the format from `filename`'s extension.
 
         Args:
-            audio_path: Path to the audio file.
+            audio: The raw audio bytes.
+            filename: Original filename; only its extension is used, to tell
+                the API what audio format it's receiving.
             language: Optional ISO 639-1 language hint (e.g. "nl").
 
         Returns:
             The transcribed text.
 
         Raises:
-            RuntimeError: If the file doesn't exist or the API call fails.
+            RuntimeError: If the API call fails.
         """
-        path = Path(audio_path)
-        if not path.is_file():
-            raise RuntimeError(f"Audio file not found: {path}")
-
         try:
-            with path.open("rb") as audio_file:
-                kwargs = {"model": self._model, "file": audio_file}
-                if language:
-                    kwargs["language"] = language
-                response = await self._client.audio.transcriptions.create(**kwargs)
+            kwargs = {"model": self._model, "file": (filename, audio)}
+            if language:
+                kwargs["language"] = language
+            response = await self._client.audio.transcriptions.create(**kwargs)
             return response.text
         except Exception as e:
-            raise RuntimeError(f"Failed to transcribe {path.name}: {e}") from e
+            raise RuntimeError(f"Failed to transcribe {filename}: {e}") from e

--- a/src/transcription/openai_whisper.py
+++ b/src/transcription/openai_whisper.py
@@ -16,6 +16,10 @@ class OpenAIWhisperTranscription(TranscriptionService):
     somewhere covered by a signed subverwerkersovereenkomst (or be replaced
     entirely by a self-hosted/AWS Transcribe pipeline) — this implementation
     is a showcase stub, not a compliant path for real patient data.
+
+    No speaker diarization: `whisper-1` returns a single undifferentiated
+    text block, not "Spreker A / Spreker B" turns. See docs/transcription.md
+    for why that's a real gap for this use case and the concrete next steps.
     """
 
     def __init__(self, api_key: str | None = None, model: str = "whisper-1"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 """Common test fixtures for healthcare multi-agent system."""
 
+import json
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import requests
@@ -11,6 +12,8 @@ from src.llm.circuit_breaker import is_ollama_available, is_openai_available
 
 # Constants
 HTTP_OK = 200
+QUALITY_SCORE = 95
+ACCURACY_SCORE = 0.95
 
 
 def is_service_available(url: str, timeout: int = 5) -> bool:
@@ -65,6 +68,58 @@ def mock_patient_data():
             "last_visit": "2024-01-15",
         }
     }
+
+
+@pytest.fixture
+def mock_task_llm():
+    """Create a mock LLM whose responses match the JSON contract each task expects.
+
+    Shared by unit task tests and the agent-system integration test so the mock
+    payloads only need to be kept in sync with `src/tasks/*` in one place.
+    """
+    llm = AsyncMock()
+
+    async def mock_ainvoke(prompt: str) -> str:
+        if "Preprocess this medical text" in prompt:
+            return "Preprocessed: Patient has hypertension"
+        elif "Assess the language proficiency" in prompt:
+            return json.dumps({"proficiency": "intermediate", "needs_interpreter": False, "language_proficiency_scale": "B2"})
+        elif "Extract clinical information" in prompt:
+            return json.dumps(
+                {
+                    "symptoms": ["headache"],
+                    "conditions": ["hypertension"],
+                    "medications": ["metoprolol"],
+                    "diagnosis": "Essential hypertension",
+                }
+            )
+        elif "Generate a concise medical summary" in prompt:
+            return "Patient presents with hypertension"
+        elif "Perform quality control" in prompt:
+            return json.dumps({"accuracy_score": ACCURACY_SCORE, "requires_human_review": False, "quality_rating": QUALITY_SCORE})
+        return "Mock response"
+
+    llm.ainvoke = mock_ainvoke
+    return llm
+
+
+@pytest.fixture
+def mock_task_db():
+    """Create a mock database returning fixed patient data for task tests."""
+    db = AsyncMock()
+    db.read_patient_data = AsyncMock(
+        return_value={"patient_id": "123", "name": "John Doe", "history": "Hypertension", "allergies": ["Penicillin"]}
+    )
+    db.propose_database_update = AsyncMock(return_value=True)
+    return db
+
+
+@pytest.fixture
+def mock_task_logger():
+    """Create a mock audit logger for task tests."""
+    logger = AsyncMock()
+    logger.log_audit_event = AsyncMock(return_value=True)
+    return logger
 
 
 @pytest.fixture

--- a/tests/integration/test_agent_system.py
+++ b/tests/integration/test_agent_system.py
@@ -1,9 +1,15 @@
-"""Integration tests for agent system."""
+"""Integration tests for the agent/task pipeline.
 
-from unittest.mock import AsyncMock
+Two tiers are covered here:
+1. A mocked run through all tasks in sequence (always runs, no external services).
+2. A live run against a real LLM provider (Ollama or OpenAI), skipped when neither
+   is available.
+"""
 
 import pytest
 
+from src.llm.circuit_breaker import is_ollama_available, is_openai_available
+from src.llm.llm_factory import LLMFactory, LLMType
 from src.tasks import (
     AssessPatientLanguageTask,
     ExtractClinicalInfoTask,
@@ -13,28 +19,9 @@ from src.tasks import (
 )
 
 
-@pytest.fixture
-def mock_llm():
-    """Create a mock LLM for testing."""
-    return AsyncMock()
-
-
-@pytest.fixture
-def mock_db():
-    """Create a mock database for testing."""
-    return AsyncMock()
-
-
-@pytest.fixture
-def mock_logger():
-    """Create a mock logger for testing."""
-    return AsyncMock()
-
-
 @pytest.mark.asyncio
-async def test_agent_system_integration(mock_llm, mock_db, mock_logger):
-    """Test the integration of all agents and tasks."""
-    # Create tasks
+async def test_agent_system_pipeline_with_mocks(mock_task_llm, mock_task_db, mock_task_logger):
+    """Test that all tasks run end-to-end in sequence against a mocked LLM."""
     tasks = [
         PreprocessMedicalTextTask(),
         AssessPatientLanguageTask(),
@@ -43,10 +30,30 @@ async def test_agent_system_integration(mock_llm, mock_db, mock_logger):
         QualityControlTask(),
     ]
 
-    # Test task execution
     for task in tasks:
         if isinstance(task, QualityControlTask):
-            result = await task.execute("Test conversation", mock_llm, mock_db, mock_logger)
+            result = await task.execute("Test conversation", mock_task_llm, mock_task_db, mock_task_logger)
         else:
-            result = await task.execute("Test conversation", mock_llm)
+            result = await task.execute("Test conversation", mock_task_llm)
         assert result is not None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_agent_system_pipeline_with_live_llm():
+    """Test the first pipeline stage against a real, running LLM provider.
+
+    Skipped automatically (via conftest.pytest_runtest_setup) when neither
+    Ollama nor an OpenAI API key is available. Deliberately only exercises
+    PreprocessMedicalTextTask, which returns free-form text rather than
+    strict JSON, so this test isn't flaky against normal LLM output variance.
+    """
+    if not (is_ollama_available() or is_openai_available()):
+        pytest.skip("No LLM service available for integration tests")
+
+    llm_type = LLMType.LOCAL_FAST if is_ollama_available() else LLMType.CLOUD_FAST
+    llm = LLMFactory.create_llm(llm_type)
+
+    result = await PreprocessMedicalTextTask().execute("Patient reports headaches for the past week.", llm)
+    assert isinstance(result, str)
+    assert len(result) > 0

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -4,6 +4,8 @@ This module contains tests that verify the functionality of the API endpoints,
 ensuring they process requests correctly and return the expected responses.
 """
 
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -49,3 +51,32 @@ def test_process_conversation_endpoint():
     ]
     for key in expected_keys:
         assert key in response_data
+
+
+def test_transcribe_and_process_endpoint(monkeypatch):
+    """Tests the /transcribe_and_process/ endpoint's wiring: file upload in,
+    transcript + pipeline results out. The transcription/LLM pipeline itself
+    is mocked here — it's covered separately by test_main.py (mocked) and
+    test_agent_system.py (live, marked integration).
+    """
+    mock_result = {
+        "transcript": "Patient heeft hoofdpijn.",
+        "preprocessed_text": "Patient has a headache.",
+        "language_assessment": {"proficiency": "intermediate", "needs_interpreter": False, "language_proficiency_scale": "B1"},
+        "clinical_info": {"symptoms": ["headache"], "conditions": [], "medications": [], "diagnosis": "Headache"},
+        "summary": "The patient reports a headache.",
+        "quality_check": {"accuracy_score": 0.9, "requires_human_review": True, "quality_rating": 90},
+    }
+    mock_process_audio = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr("src.api.api_server.process_audio_conversation_async", mock_process_audio)
+
+    response = client.post(
+        "/transcribe_and_process/",
+        files={"audio": ("consult.wav", b"fake-audio-bytes", "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == mock_result
+    mock_process_audio.assert_called_once()
+    args, kwargs = mock_process_audio.call_args
+    assert kwargs.get("language") == "nl"

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -4,6 +4,7 @@ This module contains tests that verify the functionality of the API endpoints,
 ensuring they process requests correctly and return the expected responses.
 """
 
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api.api_server import app
@@ -12,8 +13,13 @@ from src.api.api_server import app
 client = TestClient(app)
 
 
+@pytest.mark.llm
 def test_process_conversation_endpoint():
     """Tests the /process_conversation/ endpoint.
+
+    This exercises the full crew pipeline via LLMType.CLOUD_FAST, which
+    requires a working OpenAI API key. Skipped automatically (see conftest.py)
+    when OPENAI_API_KEY isn't set or the API isn't reachable.
 
     Verifies that:
     1. The endpoint returns a successful response (status code 200).

--- a/tests/integration/test_llm_connectivity.py
+++ b/tests/integration/test_llm_connectivity.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 
 from src.llm.circuit_breaker import is_ollama_available, is_openai_available
-from src.llm.llm_factory import LLMFactory, LLMType
+from src.llm.llm_factory import LLMFactory, LLMType, get_llm
 
 
 # Constants
@@ -78,7 +78,7 @@ def test_factory_fallback_from_openai_to_ollama():
     if not is_ollama_available():
         pytest.skip("Ollama must be available to test the fallback mechanism.")
 
-    with patch("src.llm.circuit_breaker.is_openai_available", return_value=False):
+    with patch("src.llm.llm_factory.is_openai_available", return_value=False):
         llm = LLMFactory.get_llm_for_task("summarization")
         assert llm is not None
         assert "ollama" in llm.__class__.__module__.lower()
@@ -86,16 +86,18 @@ def test_factory_fallback_from_openai_to_ollama():
 
 @pytest.mark.integration
 def test_factory_fallback_from_ollama_to_openai():
-    """Test the factory's fallback mechanism from Ollama to OpenAI.
+    """Test the fallback mechanism from Ollama to OpenAI.
 
-    Verifies that if Ollama is unavailable, the factory's `get_llm_for_task`
-    method correctly falls back to an available OpenAI model.
+    Verifies that if Ollama is unavailable, `get_llm(provider="ollama")`
+    correctly falls back to an available OpenAI model. (`get_llm_for_task`
+    always starts from a cloud/OpenAI default, so it can't exercise this
+    branch — `get_llm` is the entry point that lets a caller request Ollama
+    directly.)
     """
     if not is_openai_available():
         pytest.skip("OpenAI must be available to test the fallback mechanism.")
 
-    with patch("src.llm.circuit_breaker.is_ollama_available", return_value=False):
-        # We need to select a type that defaults to local
-        llm = LLMFactory.create_llm(LLMType.LOCAL_FAST)
+    with patch("src.llm.llm_factory.is_ollama_available", return_value=False):
+        llm = get_llm(provider="ollama")
         assert llm is not None
         assert "openai" in llm.__class__.__module__.lower()

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -27,14 +27,32 @@ NUM_AGENTS_IN_CREW = 5
 def mock_llm():
     """Create a mock LLM for testing.
 
+    `crewai.Agent` doesn't accept an arbitrary object as `llm` as-is: its
+    pydantic validator runs it through `create_llm()`
+    (`crewai/utilities/llm_utils.py`), which reads specific attributes
+    (`model_name`, not `model`) to build a real `crewai.LLM`. Any attribute
+    it reads that's left unset on an AsyncMock auto-vivifies into another
+    mock rather than `None`, which breaks `create_llm`'s string handling
+    (e.g. `model_name.lower()` on a mock) and makes it silently fall back to
+    `self.llm = None` — surfacing later as a confusing
+    `AttributeError: 'NoneType' object has no attribute 'supports_stop_words'`
+    instead of a clear failure here. So every attribute `create_llm` reads
+    must be set explicitly, matching its real names.
+
     Returns:
         An AsyncMock object that simulates an LLM for testing agent creation
     """
     mock = AsyncMock()
     mock.supports_stop_words = lambda: False
-    mock.model = "gpt-4"
+    mock.model_name = "gpt-4"
+    mock.deployment_name = None
     mock.temperature = 0.7
     mock.max_tokens = 1000
+    mock.logprobs = None
+    mock.timeout = None
+    mock.api_key = None
+    mock.base_url = None
+    mock.api_base = None
     mock.tools = []
     return mock
 

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -29,11 +29,14 @@ def mock_llm():
 
     `crewai.Agent` doesn't accept an arbitrary object as `llm` as-is: its
     pydantic validator runs it through `create_llm()`
-    (`crewai/utilities/llm_utils.py`), which reads specific attributes
-    (`model_name`, not `model`) to build a real `crewai.LLM`. Any attribute
-    it reads that's left unset on an AsyncMock auto-vivifies into another
-    mock rather than `None`, which breaks `create_llm`'s string handling
-    (e.g. `model_name.lower()` on a mock) and makes it silently fall back to
+    (`crewai/utilities/llm_utils.py`), which reads specific attributes to
+    build a real `crewai.LLM`. The model name is resolved as
+    `getattr(llm, "model", None) or getattr(llm, "model_name", None) or
+    getattr(llm, "deployment_name", None)` — so `model` is tried first, and
+    on crewai 0.117.x that attribute must carry the string. Any attribute it
+    reads that's left unset on an AsyncMock auto-vivifies into another mock
+    rather than `None`, which breaks `create_llm`'s string handling
+    (e.g. `model.lower()` on a mock) and makes it silently fall back to
     `self.llm = None` — surfacing later as a confusing
     `AttributeError: 'NoneType' object has no attribute 'supports_stop_words'`
     instead of a clear failure here. So every attribute `create_llm` reads
@@ -44,6 +47,7 @@ def mock_llm():
     """
     mock = AsyncMock()
     mock.supports_stop_words = lambda: False
+    mock.model = "gpt-4"
     mock.model_name = "gpt-4"
     mock.deployment_name = None
     mock.temperature = 0.7

--- a/tests/unit/test_llm_adapters.py
+++ b/tests/unit/test_llm_adapters.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.callbacks.manager import CallbackManagerForLLMRun
+from pydantic import SecretStr
 
 from src.llm.ollama_llm import OllamaLLM
 from src.llm.openai_llm import OpenAILLM
@@ -40,7 +41,7 @@ class TestOpenAILLM:
     4. Temperature setting and retrieval
     """
 
-    @patch("langchain_openai.ChatOpenAI")
+    @patch("src.llm.openai_llm.ChatOpenAI")
     def test_initialization_with_api_key(self, mock_chat_openai):
         """Test initialization with explicit API key.
 
@@ -58,13 +59,13 @@ class TestOpenAILLM:
         llm = OpenAILLM(model_name="gpt-4", temperature=TEST_TEMPERATURE_LOW, api_key="test-key")
 
         # Assert
-        mock_chat_openai.assert_called_once_with(model="gpt-4", temperature=TEST_TEMPERATURE_LOW, openai_api_key="test-key")
+        mock_chat_openai.assert_called_once_with(model="gpt-4", temperature=TEST_TEMPERATURE_LOW, api_key=SecretStr("test-key"))
         assert llm.model_name == "gpt-4"
         assert llm.temperature == TEST_TEMPERATURE_LOW
         assert llm.provider == "openai"
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "env-key"})
-    @patch("langchain_openai.ChatOpenAI")
+    @patch("src.llm.openai_llm.ChatOpenAI")
     def test_initialization_with_env_api_key(self, mock_chat_openai):
         """Test initialization with API key from environment variables.
 
@@ -83,7 +84,7 @@ class TestOpenAILLM:
 
         # Assert
         mock_chat_openai.assert_called_once_with(
-            model="gpt-3.5-turbo", temperature=TEST_TEMPERATURE_MEDIUM, openai_api_key="env-key"
+            model="gpt-3.5-turbo", temperature=TEST_TEMPERATURE_MEDIUM, api_key=SecretStr("env-key")
         )
         assert llm.model_name == "gpt-3.5-turbo"
         assert llm.temperature == TEST_TEMPERATURE_MEDIUM
@@ -102,7 +103,7 @@ class TestOpenAILLM:
             with pytest.raises(ValueError, match="OpenAI API key not provided"):
                 OpenAILLM()
 
-    @patch("langchain_openai.ChatOpenAI")
+    @patch("src.llm.openai_llm.ChatOpenAI")
     def test_call_method(self, mock_chat_openai):
         """Test the _call method for basic text generation.
 
@@ -124,7 +125,7 @@ class TestOpenAILLM:
         mock_instance.invoke.assert_called_once_with("Test prompt")
         assert result == "Test response"
 
-    @patch("langchain_openai.ChatOpenAI")
+    @patch("src.llm.openai_llm.ChatOpenAI")
     def test_call_method_with_stop_and_run_manager(self, mock_chat_openai):
         """Test the _call method with stop sequences and run manager.
 
@@ -149,7 +150,7 @@ class TestOpenAILLM:
         mock_instance.invoke.assert_called_once_with("Test prompt")
         assert result == "Test response"
 
-    @patch("langchain_openai.ChatOpenAI")
+    @patch("src.llm.openai_llm.ChatOpenAI")
     def test_temperature_setter(self, mock_chat_openai):
         """Test the temperature setter method.
 
@@ -182,7 +183,7 @@ class TestOllamaLLM:
     4. Temperature setting and retrieval
     """
 
-    @patch("langchain_community.chat_models.ChatOllama")
+    @patch("src.llm.ollama_llm.ChatOllama")
     def test_initialization_with_base_url(self, mock_chat_ollama):
         """Test initialization with explicit base URL.
 
@@ -206,7 +207,7 @@ class TestOllamaLLM:
         assert llm.provider == "ollama"
 
     @patch.dict(os.environ, {"OLLAMA_BASE_URL": "http://env:11434"})
-    @patch("langchain_community.chat_models.ChatOllama")
+    @patch("src.llm.ollama_llm.ChatOllama")
     def test_initialization_with_env_base_url(self, mock_chat_ollama):
         """Test initialization with base URL from environment variables.
 
@@ -231,7 +232,7 @@ class TestOllamaLLM:
         assert llm.temperature == TEST_TEMPERATURE_MEDIUM
         assert llm.provider == "ollama"
 
-    @patch("langchain_community.chat_models.ChatOllama")
+    @patch("src.llm.ollama_llm.ChatOllama")
     def test_call_method(self, mock_chat_ollama):
         """Test the _call method for basic text generation.
 
@@ -253,7 +254,7 @@ class TestOllamaLLM:
         mock_instance.invoke.assert_called_once_with("Test prompt")
         assert result == "Test response"
 
-    @patch("langchain_community.chat_models.ChatOllama")
+    @patch("src.llm.ollama_llm.ChatOllama")
     def test_call_method_with_stop_and_run_manager(self, mock_chat_ollama):
         """Test the _call method with stop sequences and run manager.
 
@@ -278,7 +279,7 @@ class TestOllamaLLM:
         mock_instance.invoke.assert_called_once_with("Test prompt")
         assert result == "Test response"
 
-    @patch("langchain_community.chat_models.ChatOllama")
+    @patch("src.llm.ollama_llm.ChatOllama")
     def test_temperature_setter(self, mock_chat_ollama):
         """Test the temperature setter method.
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,39 @@
+"""Unit tests for the top-level pipeline entry points in src/main.py."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.main import process_audio_conversation_async, process_medical_conversation_async
+
+
+@pytest.mark.asyncio
+async def test_process_medical_conversation_async_runs_full_pipeline(mock_task_llm, monkeypatch):
+    """The text pipeline runs all five tasks and returns their combined results."""
+    monkeypatch.setattr("src.main.LLMFactory.get_llm_for_task", lambda *a, **kw: mock_task_llm)
+
+    result = await process_medical_conversation_async("Patient has hypertension.")
+
+    assert set(result.keys()) == {
+        "preprocessed_text",
+        "language_assessment",
+        "clinical_info",
+        "summary",
+        "quality_check",
+    }
+    assert result["quality_check"]["requires_human_review"] is False
+
+
+@pytest.mark.asyncio
+async def test_process_audio_conversation_async_transcribes_then_processes(mock_task_llm, monkeypatch):
+    """The audio pipeline transcribes first, then runs the same task pipeline."""
+    monkeypatch.setattr("src.main.LLMFactory.get_llm_for_task", lambda *a, **kw: mock_task_llm)
+
+    mock_transcriber = AsyncMock()
+    mock_transcriber.transcribe.return_value = "Patient has hypertension."
+
+    result = await process_audio_conversation_async("fake/path.wav", transcription_service=mock_transcriber)
+
+    mock_transcriber.transcribe.assert_called_once_with("fake/path.wav", language="nl")
+    assert result["transcript"] == "Patient has hypertension."
+    assert "summary" in result

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -30,10 +30,10 @@ async def test_process_audio_conversation_async_transcribes_then_processes(mock_
     monkeypatch.setattr("src.main.LLMFactory.get_llm_for_task", lambda *a, **kw: mock_task_llm)
 
     mock_transcriber = AsyncMock()
-    mock_transcriber.transcribe.return_value = "Patient has hypertension."
+    mock_transcriber.transcribe_file.return_value = "Patient has hypertension."
 
     result = await process_audio_conversation_async("fake/path.wav", transcription_service=mock_transcriber)
 
-    mock_transcriber.transcribe.assert_called_once_with("fake/path.wav", language="nl")
+    mock_transcriber.transcribe_file.assert_called_once_with("fake/path.wav", language="nl")
     assert result["transcript"] == "Patient has hypertension."
     assert "summary" in result

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -6,9 +6,6 @@ assessing patient language proficiency, extracting clinical information,
 generating summaries, and performing quality control.
 """
 
-import json
-from unittest.mock import AsyncMock
-
 import pytest
 
 from src.tasks import (
@@ -26,65 +23,21 @@ ACCURACY_SCORE = 0.95
 
 
 @pytest.fixture
-def mock_llm():
-    """Create a mock LLM for testing.
-
-    Returns:
-        An AsyncMock object that simulates an LLM with predefined responses
-    """
-    llm = AsyncMock()
-
-    async def mock_ainvoke(prompt: str) -> str:
-        """Mock LLM response based on the prompt."""
-        if "Preprocess this medical text" in prompt:
-            return "Preprocessed: Patient has hypertension"
-        elif "Assess the language proficiency" in prompt:
-            return json.dumps({"proficiency": "intermediate", "needs_interpreter": False, "language_proficiency": "B2"})
-        elif "Extract clinical information" in prompt:
-            return json.dumps(
-                {
-                    "symptoms": ["headache"],
-                    "conditions": ["hypertension"],
-                    "medications": ["metoprolol"],
-                    "diagnosis": "Essential hypertension",
-                }
-            )
-        elif "Generate a concise medical summary" in prompt:
-            return "Patient presents with hypertension"
-        elif "Perform quality control" in prompt:
-            return json.dumps({"accuracy": ACCURACY_SCORE, "needs_review": False, "quality_score": QUALITY_SCORE})
-        return "Mock response"
-
-    llm.ainvoke = mock_ainvoke
-    return llm
+def mock_llm(mock_task_llm):
+    """Alias onto the shared mock LLM fixture from conftest.py."""
+    return mock_task_llm
 
 
 @pytest.fixture
-def mock_db():
-    """Create a mock database for testing.
-
-    Returns:
-        An AsyncMock object that simulates a database with patient data
-        and methods for reading and updating data
-    """
-    db = AsyncMock()
-    db.read_patient_data = AsyncMock(
-        return_value={"patient_id": "123", "name": "John Doe", "history": "Hypertension", "allergies": ["Penicillin"]}
-    )
-    db.propose_database_update = AsyncMock(return_value=True)
-    return db
+def mock_db(mock_task_db):
+    """Alias onto the shared mock database fixture from conftest.py."""
+    return mock_task_db
 
 
 @pytest.fixture
-def mock_logger():
-    """Create a mock logger for testing.
-
-    Returns:
-        An AsyncMock object that simulates a logger with audit event logging
-    """
-    logger = AsyncMock()
-    logger.log_audit_event = AsyncMock(return_value=True)
-    return logger
+def mock_logger(mock_task_logger):
+    """Alias onto the shared mock logger fixture from conftest.py."""
+    return mock_task_logger
 
 
 @pytest.mark.asyncio
@@ -117,10 +70,10 @@ async def test_assess_patient_language_task(mock_llm):
     assert isinstance(result, dict)
     assert "proficiency" in result
     assert "needs_interpreter" in result
-    assert "language_proficiency" in result
+    assert "language_proficiency_scale" in result
     assert result["proficiency"] == "intermediate"
     assert result["needs_interpreter"] is False
-    assert result["language_proficiency"] == "B2"
+    assert result["language_proficiency_scale"] == "B2"
 
 
 @pytest.mark.asyncio
@@ -172,12 +125,12 @@ async def test_quality_control_task(mock_llm, mock_db, mock_logger):
     task = QualityControlTask()
     result = await task.execute("Patient summary", mock_llm, mock_db, mock_logger)
     assert isinstance(result, dict)
-    assert "accuracy" in result
-    assert "needs_review" in result
-    assert "quality_score" in result
-    assert result["accuracy"] == ACCURACY_SCORE
-    assert result["needs_review"] is False
-    assert result["quality_score"] == QUALITY_SCORE
+    assert "accuracy_score" in result
+    assert "requires_human_review" in result
+    assert "quality_rating" in result
+    assert result["accuracy_score"] == ACCURACY_SCORE
+    assert result["requires_human_review"] is False
+    assert result["quality_rating"] == QUALITY_SCORE
 
     # Verify database and logger interactions
     mock_db.read_patient_data.assert_called_once()

--- a/tests/unit/test_transcription.py
+++ b/tests/unit/test_transcription.py
@@ -1,0 +1,62 @@
+"""Unit tests for the transcription providers."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.transcription.openai_whisper import OpenAIWhisperTranscription
+
+
+class TestOpenAIWhisperTranscription:
+    """Tests for the OpenAI Whisper API transcription provider."""
+
+    def test_initialization_without_api_key(self):
+        """A ValueError is raised when no API key is available."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="OpenAI API key not provided"):
+                OpenAIWhisperTranscription()
+
+    @pytest.mark.asyncio
+    @patch("src.transcription.openai_whisper.AsyncOpenAI")
+    async def test_transcribe_missing_file(self, mock_openai_cls):
+        """A RuntimeError is raised when the audio file doesn't exist."""
+        provider = OpenAIWhisperTranscription(api_key="test-key")
+
+        with pytest.raises(RuntimeError, match="Audio file not found"):
+            await provider.transcribe("this/path/does/not/exist.wav")
+
+    @pytest.mark.asyncio
+    @patch("src.transcription.openai_whisper.AsyncOpenAI")
+    async def test_transcribe_returns_text(self, mock_openai_cls, tmp_path):
+        """The provider forwards the audio file and returns the transcribed text."""
+        audio_path = tmp_path / "sample.wav"
+        audio_path.write_bytes(b"fake-audio-bytes")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=MagicMock(text="Patient heeft hoofdpijn."))
+        mock_openai_cls.return_value = mock_client
+
+        provider = OpenAIWhisperTranscription(api_key="test-key")
+        result = await provider.transcribe(audio_path, language="nl")
+
+        assert result == "Patient heeft hoofdpijn."
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert kwargs["model"] == "whisper-1"
+        assert kwargs["language"] == "nl"
+
+    @pytest.mark.asyncio
+    @patch("src.transcription.openai_whisper.AsyncOpenAI")
+    async def test_transcribe_wraps_api_errors(self, mock_openai_cls, tmp_path):
+        """API failures are wrapped in a RuntimeError with context."""
+        audio_path = tmp_path / "sample.wav"
+        audio_path.write_bytes(b"fake-audio-bytes")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create = AsyncMock(side_effect=Exception("rate limited"))
+        mock_openai_cls.return_value = mock_client
+
+        provider = OpenAIWhisperTranscription(api_key="test-key")
+
+        with pytest.raises(RuntimeError, match="Failed to transcribe"):
+            await provider.transcribe(audio_path)

--- a/tests/unit/test_transcription.py
+++ b/tests/unit/test_transcription.py
@@ -19,17 +19,34 @@ class TestOpenAIWhisperTranscription:
 
     @pytest.mark.asyncio
     @patch("src.transcription.openai_whisper.AsyncOpenAI")
-    async def test_transcribe_missing_file(self, mock_openai_cls):
+    async def test_transcribe_file_missing_file(self, mock_openai_cls):
         """A RuntimeError is raised when the audio file doesn't exist."""
         provider = OpenAIWhisperTranscription(api_key="test-key")
 
         with pytest.raises(RuntimeError, match="Audio file not found"):
-            await provider.transcribe("this/path/does/not/exist.wav")
+            await provider.transcribe_file("this/path/does/not/exist.wav")
 
     @pytest.mark.asyncio
     @patch("src.transcription.openai_whisper.AsyncOpenAI")
-    async def test_transcribe_returns_text(self, mock_openai_cls, tmp_path):
-        """The provider forwards the audio file and returns the transcribed text."""
+    async def test_transcribe_returns_text(self, mock_openai_cls):
+        """The provider forwards the audio bytes and returns the transcribed text."""
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create = AsyncMock(return_value=MagicMock(text="Patient heeft hoofdpijn."))
+        mock_openai_cls.return_value = mock_client
+
+        provider = OpenAIWhisperTranscription(api_key="test-key")
+        result = await provider.transcribe(b"fake-audio-bytes", filename="sample.wav", language="nl")
+
+        assert result == "Patient heeft hoofdpijn."
+        _, kwargs = mock_client.audio.transcriptions.create.call_args
+        assert kwargs["model"] == "whisper-1"
+        assert kwargs["language"] == "nl"
+        assert kwargs["file"] == ("sample.wav", b"fake-audio-bytes")
+
+    @pytest.mark.asyncio
+    @patch("src.transcription.openai_whisper.AsyncOpenAI")
+    async def test_transcribe_file_reads_then_transcribes(self, mock_openai_cls, tmp_path):
+        """`transcribe_file` reads the file into memory and delegates to `transcribe`."""
         audio_path = tmp_path / "sample.wav"
         audio_path.write_bytes(b"fake-audio-bytes")
 
@@ -38,20 +55,16 @@ class TestOpenAIWhisperTranscription:
         mock_openai_cls.return_value = mock_client
 
         provider = OpenAIWhisperTranscription(api_key="test-key")
-        result = await provider.transcribe(audio_path, language="nl")
+        result = await provider.transcribe_file(audio_path, language="nl")
 
         assert result == "Patient heeft hoofdpijn."
         _, kwargs = mock_client.audio.transcriptions.create.call_args
-        assert kwargs["model"] == "whisper-1"
-        assert kwargs["language"] == "nl"
+        assert kwargs["file"] == ("sample.wav", b"fake-audio-bytes")
 
     @pytest.mark.asyncio
     @patch("src.transcription.openai_whisper.AsyncOpenAI")
-    async def test_transcribe_wraps_api_errors(self, mock_openai_cls, tmp_path):
+    async def test_transcribe_wraps_api_errors(self, mock_openai_cls):
         """API failures are wrapped in a RuntimeError with context."""
-        audio_path = tmp_path / "sample.wav"
-        audio_path.write_bytes(b"fake-audio-bytes")
-
         mock_client = MagicMock()
         mock_client.audio.transcriptions.create = AsyncMock(side_effect=Exception("rate limited"))
         mock_openai_cls.return_value = mock_client
@@ -59,4 +72,4 @@ class TestOpenAIWhisperTranscription:
         provider = OpenAIWhisperTranscription(api_key="test-key")
 
         with pytest.raises(RuntimeError, match="Failed to transcribe"):
-            await provider.transcribe(audio_path)
+            await provider.transcribe(b"fake-audio-bytes", filename="sample.wav")

--- a/tests/unit/test_transcription_factory.py
+++ b/tests/unit/test_transcription_factory.py
@@ -1,0 +1,32 @@
+"""Unit tests for the transcription provider factory."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.transcription.factory import TranscriptionFactory
+from src.transcription.openai_whisper import OpenAIWhisperTranscription
+
+
+class TestTranscriptionFactory:
+    """Tests for `TranscriptionFactory.create`."""
+
+    def test_defaults_to_openai(self):
+        """With no provider specified, the factory creates the OpenAI provider."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True):
+            service = TranscriptionFactory.create()
+
+        assert isinstance(service, OpenAIWhisperTranscription)
+
+    def test_reads_provider_from_env_var(self):
+        """`TRANSCRIPTION_PROVIDER` selects the provider when no override is passed."""
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key", "TRANSCRIPTION_PROVIDER": "OpenAI"}, clear=True):
+            service = TranscriptionFactory.create()
+
+        assert isinstance(service, OpenAIWhisperTranscription)
+
+    def test_unsupported_provider_raises(self):
+        """An unregistered provider name raises a clear ValueError."""
+        with pytest.raises(ValueError, match="Unsupported transcription provider"):
+            TranscriptionFactory.create("azure")


### PR DESCRIPTION
## Summary
- Fix broken mocks and stale assertions in the existing test suite
- Repair the broken CrewAI pipeline wiring in main.py/api_server.py
- Add a transcription stage ahead of the agent pipeline
- Add GGZ/healthcare compliance considerations
- Document speaker diarization as a next step, not a silent gap
- Add Claude Code agent skill configuration

## Findings / requirements baseline

This PR was rework without a tracking issue. #6 is the retroactive findings +
requirements + verification issue for this revival — it records everything
found wrong in the project state (F1–F3 fixed here, F4–F11 still open) with
IEC 62304 Class A–style traceability (REQ-# → file → test). Closes the
"revive without a paper trail" gap; does not close #6 itself (most findings
are follow-up work).

## Test plan

Unit tier (must be green before merge, no external services required):
- [x] `PYTHONUTF8=1 uv run pytest tests/unit -v` — all unit tests pass
- [x] `uv run ruff check . && uv run ruff format --check .` — clean

Pipeline wiring (verifies F1/F3 — the actual bug this PR fixes):
- [x] `PYTHONUTF8=1 uv run pytest tests/unit/test_main.py -v` — both
      `process_medical_conversation_async` / `process_audio_conversation_async`
      tests pass against the mocked pipeline
- [ ] Live smoke test against a real provider (Ollama `llama3` or
      `OPENAI_API_KEY`) per #6's F1 verification steps — confirm
      `process_medical_conversation(...)` returns all five pipeline keys with
      no `ValidationError`/`AttributeError`

Mock integrity (verifies F2 — mocks patch what the code actually imports):
- [ ] `PYTHONUTF8=1 env -u OPENAI_API_KEY uv run pytest tests/unit/test_llm_adapters.py tests/unit/test_tasks.py tests/unit/test_agents.py -v`
      with no `OPENAI_API_KEY` set and no network — proves the mocks are
      load-bearing, not silently falling through

Transcription stage (new in this PR):
- [ ] `PYTHONUTF8=1 uv run pytest tests/unit/test_transcription.py tests/unit/test_transcription_factory.py -v`
- [ ] `PYTHONUTF8=1 uv run pytest tests/integration/test_api.py -v -k transcribe_and_process` —
      endpoint wiring test (mocked transcription/LLM) passes

Full suite:
- [ ] `PYTHONUTF8=1 uv run pytest -v` — expect `59 passed, 17 skipped` locally
      with no external services configured (skips are the integration/live-LLM
      tier; see #6 F10 for why nothing runs those automatically yet)

Known gaps this PR does **not** close (tracked in #6, not blocking this merge):
CI still doesn't run `pytest`/`ruff` (F4), `src/agents/*` is now dead code
still exercised only by `test_agents.py` (F5), the quality-control JSON
contract isn't type/range-validated (F6).
